### PR TITLE
Clarify license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2014, 2015 Joerg Fiedler
+Copyright 2015 Johannes Jost Meixner
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY [COPYRIGHT HOLDER] AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL [COPYRIGHT HOLDER] OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
Hi Joerg,

I'm currently working with @pannon on bringing Ansible support for iocage up to par.
Your codebase seems like it's almost doing everything I'd like it to, and the remaining features I will submit as pull requests.

Given that we're working on the same goal, which is making iocage support in ansible // ansible support with iocage superior, I'd like to clarify the license.

I'm sure you have already thought about it. As did I - from my personal preference as FreeBSD developer, the two-clause BSD license (see below) seems the right choice.

Other licenses to look at could include the ISC License and the MIT license.
The differences are relatively similar, and the FreeBSD license adds some small amount of
FreeBSD advocacy to it.

Best regards,
Johannes Meixner

Schöne Grüsse aus Tallinn :-)
